### PR TITLE
Fixed error caused by NoneType object access

### DIFF
--- a/billboard.py
+++ b/billboard.py
@@ -71,7 +71,10 @@ class ChartData:
                 if len(chartInfoSoup.contents) >= 4:
                     # Chart info includes both artist and album info
                     artist = chartInfoSoup.contents[1].string
-                    album = chartInfoSoup.contents[3].string.strip()
+                    if chartInfoSoup.contents[3].string:
+                        album = chartInfoSoup.contents[3].string.strip()
+                    else:
+                        album = None
                 else:
                     album = None  # Chart info includes only artist info
                     if chartInfoSoup.find('a'):


### PR DESCRIPTION
I was encountering this error:

```
Traceback (most recent call last):
  File "core/main.py", line 65, in run
    out = func(input.inp)
  File "plugins/porktrack.py", line 24, in porktrack
    a = billboard.ChartData('hot-100', date=datetime.strftime(date, "%Y-%m-%d"))
  File "lib/billboard.py", line 45, in __init__
    self.fetchEntries(all=all)
  File "lib/billboard.py", line 74, in fetchEntries
    album = chartInfoSoup.contents[3].string.strip()
AttributeError: 'NoneType' object has no attribute 'strip'
```

I fixed it locally, thought I might PR it so others can use it.
