### PR TITLE
Added a previousDate field (and tests and doc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ The arguments are:
 * `fetch` &ndash; A boolean indicating whether to fetch the chart data from Billboard.com immediately (at instantiation time). If `False`, the chart data can be populated at a later time using the `fetchEntries()` method.
 * `all` &ndash; Deprecated; has no effect.
 
+### Walking through chart dates
+
+Every `ChartData` instance has a `previousDate` attribute containing a string representation of the previous chart's date. You can feed this into another `ChartData` instance to effectively walk back through previous charts.
+
+```python
+import billboard
+from time import sleep
+
+chart = billboard.ChartData('hot-100')
+while chart.previousDate:
+  doSomething(chart)
+  chart = billboard.ChartData('hot-100', chart.previousDate)
+  sleep(2) # try not to hammer Billboard.
+
+``` 
+
 ### Accessing chart entries
 
 If `chart` is a `ChartData` instance, we can ask for its `entries` attribute to get the chart entries (see below) as a list.

--- a/billboard.py
+++ b/billboard.py
@@ -93,6 +93,7 @@ class ChartData:
             all: Deprecated; has no effect.
         """
         self.name = name
+        self.previousDate = None
         if date:
             self.date = date
             self.latest = False
@@ -148,6 +149,12 @@ class ChartData:
 
         html = downloadHTML(url)
         soup = BeautifulSoup(html, 'html.parser')
+
+        prevLink = soup.find('a', {'title': 'Previous Week'})
+        if prevLink:
+            # Extract the previous date from the link. 
+            # eg, /charts/country-songs/2016-02-13
+            self.previousDate = prevLink.get('href').split('/')[-1]
 
         for entry_soup in soup.find_all('article', {'class': 'chart-row'}):
 

--- a/tests/test_billboard.py
+++ b/tests/test_billboard.py
@@ -62,6 +62,14 @@ class DetailedHistoricalHot100Test(CurrentHot100Test):
             normalized_ref_json = reference.read().strip().replace(' ', '')
             assert normalized_ref_json == normalized_chart_json
 
+class PreviousDateTest(unittest.TestCase):
+
+    def setUp(self):
+        self.chart = billboard.ChartData('hot-100', date='2016-02-13')
+
+    def test_correct_fields(self):
+        assert self.chart.previousDate == '2016-02-06'
+
 
 def get_test_dir():
     return os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
I found myself wanting to walk back and collect a few weeks worth of chart data, so this patch automatically collects the previous chart date every time you instantiate a ChartData object.

You could do the same thing with nextDate too I suppose. 