### PR TITLE
VideoLink property and updated tests

### DIFF
--- a/billboard.py
+++ b/billboard.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import json
 import requests
+import datetime
 from bs4 import BeautifulSoup
 
 """billboard.py: Unofficial Python API for accessing ranking charts from Billboard.com."""
@@ -68,7 +69,7 @@ class ChartData:
     """Represents a particular Billboard chart for a particular date.
     """
 
-    def __init__(self, name, date=None, fetch=True, all=False):
+    def __init__(self, name, date=None, fetch=True, all=False, quantize=True):
         """Constructs a new ChartData instance.
 
         By default, this constructor will download the requested data from
@@ -92,10 +93,14 @@ class ChartData:
                 If False, the chart data can be populated at a later time
                 using the fetchEntries() method.
             all: Deprecated; has no effect.
+            quantize: A boolean indicating whether or not to quantize the
+                date passed to the nearest date with a chart entry
         """
         self.name = name
         self.previousDate = None
         if date:
+            if quantize:
+                date = self._quantize_date(date)
             self.date = date
             self.latest = False
         else:
@@ -128,6 +133,27 @@ class ChartData:
         A length of zero may indicated a failed/bad request.
         """
         return len(self.entries)
+
+    def _quantize_date(self, date):
+        """Quantizes the passed date to the nearest Saturday, since
+        Billboard charts are always dated by Saturday.
+        This behavior is consistent with the website, even though charts
+        are released 11 days in advance.
+        EG, entering 2016-07-19 corresponds to the chart dated 2016-07-23
+
+        Args:
+            date: The chart date as a string, in YYYY-MM-DD format.
+        """
+        year, month, day = [int(x) for x in date.split('-')]
+        passedDate = datetime.date(year, month, day)
+        passedWeekday = passedDate.weekday()
+        if passedWeekday == 5:  # saturday
+            return date
+        elif passedWeekday == 6:  # sunday
+            quantizedDate = passedDate + datetime.timedelta(days=6)
+        else:
+            quantizedDate = passedDate + datetime.timedelta(days=5 - passedWeekday)
+        return str(quantizedDate)
 
     def to_JSON(self):
         """Returns the entry as a JSON string.

--- a/billboard.py
+++ b/billboard.py
@@ -39,7 +39,7 @@ class ChartEntry:
             spotifyID. Will be an empty string if no such ID was provided.
     """
 
-    def __init__(self, title, artist, peakPos, lastPos, weeks, rank, change, spotifyID, spotifyLink):
+    def __init__(self, title, artist, peakPos, lastPos, weeks, rank, change, spotifyID, spotifyLink, videoLink):
         """Constructs a new ChartEntry instance with given attributes.
         """
         self.title = title
@@ -51,6 +51,7 @@ class ChartEntry:
         self.change = change
         self.spotifyLink = spotifyLink
         self.spotifyID = spotifyID
+        self.videoLink = videoLink
 
     def __repr__(self):
         """Returns a string of the form 'TITLE by ARTIST'.
@@ -236,10 +237,16 @@ class ChartData:
                 spotifyID = ''
                 spotifyLink = ''
 
+            videoElement = entrySoup.find('a', 'chart-row__link--video')
+            if videoElement:
+                videoLink = videoElement.get('data-href')
+            else:
+                videoLink = ''
+
             self.entries.append(
                 ChartEntry(title, artist, peakPos,
                            lastPos, weeks, rank, change,
-                           spotifyID, spotifyLink))
+                           spotifyID, spotifyLink, videoLink))
 
         # Hot Shot Debut is the top-ranked new entry, or the first "New" entry
         # we find.

--- a/tests/test_billboard.py
+++ b/tests/test_billboard.py
@@ -63,16 +63,31 @@ class HistoricalHot100Test(CurrentHot100Test):
             assert str(self.chart) == reference.read()
 
 
-class InvalidDateTest(unittest.TestCase):
+class QuantizeDateTest(unittest.TestCase):
+    """Checks that the ChartData object created when the date is invalid
+    quantizes to valid date.
+    """
+
+    def setUp(self):
+        self.chart = billboard.ChartData('hot-100', date='2016-02-12')
+        self.chart2 = billboard.ChartData('hot-100', date='2016-02-14')
+
+    def test_correct_entries(self):
+        assert len(self.chart) == 100
+        assert len(self.chart2) == 100
+
+
+class VideoLinkTest(unittest.TestCase):
     """Checks that the ChartData object created when the date is invalid
     has no entries.
     """
 
     def setUp(self):
-        self.chart = billboard.ChartData('hot-100', date='2016-02-12')
+        self.chart = billboard.ChartData('hot-100', date='2016-07-26')
 
     def test_correct_entries(self):
-        assert len(self.chart) == 0
+        assert self.chart.entries[31].videoLink == 'http://cache.vevo.com/assets/html/embed.html?video=USSM21600522&partnerId=0bcf11f5-81bc-469a-a74f-b370f19def6e&siteSection=billboard_billboard.com'
+        assert not self.chart.entries[32].videoLink
 
 
 def get_test_dir():


### PR DESCRIPTION
Added Vevo links as a `videoLink` property if the entry has them. These go back decades!
Also added tests for `videoLink`, as well as changed `InvalidDateTest` to `QuantizeDateTest`, which tests that Fridays and Sundays quantize to the correct respective Saturdays.