### PR TITLE
ChartData accepts date.datetime object in addition to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ ChartData(name, date=None, fetch=True, all=False, quantize=True)
 
 The arguments are:
 
-* `name` &ndash; The chart name, e.g. `'hot-100'` or `'pop-songs'`. You can browse the Charts section of Billboard.com to find valid chart names; the URL of a chart will look like `http://www.billboard.com/charts/CHART-NAME` ([example](http://www.billboard.com/charts/artist-100)).
+* `name` &ndash; The chart name, e.g. `'hot-100'` or `'pop-songs'`. You can browse the [Charts page](http://www.billboard.com/charts) on Billboard.com to find valid chart names; the URL of a chart will look like `http://www.billboard.com/charts/CHART-NAME` ([example](http://www.billboard.com/charts/artist-100)). Almost any chart should work; the only chart known not to work is `spotify-rewind`.
 * `date` &ndash; The chart date as a string, in YYYY-MM-DD format. By default, the latest chart is fetched.
 * `fetch` &ndash; A boolean indicating whether to fetch the chart data from Billboard.com immediately (at instantiation time). If `False`, the chart data can be populated at a later time using the `fetchEntries()` method.
 * `all` &ndash; Deprecated; has no effect.

--- a/billboard.py
+++ b/billboard.py
@@ -149,15 +149,21 @@ class ChartData:
         Args:
             date: The chart date as a string, in YYYY-MM-DD format.
         """
-        year, month, day = map(int, date.split('-'))
-        passedDate = datetime.date(year, month, day)
+        assert any(isinstance(date, x) for x in (str, datetime.date)
+                   ), 'Provided date must be str or datetime.date'
+        if isinstance(date, str):
+            year, month, day = map(int, date.split('-'))
+            passedDate = datetime.date(year, month, day)
+        elif isinstance(date, datetime.date):
+            passedDate = date
         passedWeekday = passedDate.weekday()
         if passedWeekday == 5:  # Saturday
             return date
         elif passedWeekday == 6:  # Sunday
             quantizedDate = passedDate + datetime.timedelta(days=6)
         else:
-            quantizedDate = passedDate + datetime.timedelta(days=5 - passedWeekday)
+            quantizedDate = passedDate + \
+                datetime.timedelta(days=5 - passedWeekday)
         return str(quantizedDate)
 
     def to_JSON(self):

--- a/billboard.py
+++ b/billboard.py
@@ -154,7 +154,7 @@ class ChartData:
         if isinstance(date, str):
             year, month, day = map(int, date.split('-'))
             passedDate = datetime.date(year, month, day)
-        elif isinstance(date, datetime.date):
+        else:
             passedDate = date
         passedWeekday = passedDate.weekday()
         if passedWeekday == 5:  # Saturday

--- a/tests/test_billboard.py
+++ b/tests/test_billboard.py
@@ -108,24 +108,6 @@ class InvalidDateTest(unittest.TestCase):
         assert len(self.chart) == 0
 
 
-<<<<<<< HEAD
-=======
-class MissingSpotifyButtonTest(unittest.TestCase):
-    """Checks that the ChartData object created when there is no green Spotify
-    button has no spotifyID/spotifyLink. This test may break if the song used
-    below is added to Spotify.
-    """
-
-    def setUp(self):
-        self.chart = billboard.ChartData('hot-100', date='2014-01-11')
-
-    def test_correct_entries(self):
-        mine = self.chart[81]  # "Mine" by Beyonce ft. Drake
-        assert mine.spotifyID == '' and mine.spotifyLink == ''
-        assert all(self.chart[i] for i in range(100) if i != 81)
-
-
->>>>>>> f9eb1ab... chartdata now accepts datetime.date as date parameter; unit test
 def get_test_dir():
     """Returns the name of the directory containing this test file.
     """

--- a/tests/test_billboard.py
+++ b/tests/test_billboard.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import unittest
+import datetime
 
 import billboard
 
@@ -20,7 +21,8 @@ class CurrentHot100Test(unittest.TestCase):
     def test_correct_fields(self):
         assert self.chart.date is not None
         assert self.chart.latest is True
-        assert list(sorted(entry.rank for entry in self.chart)) == list(range(1, 101))
+        assert list(sorted(entry.rank for entry in self.chart)
+                    ) == list(range(1, 101))
 
     def test_valid_entries(self):
         assert len(self.chart) == 100
@@ -28,12 +30,12 @@ class CurrentHot100Test(unittest.TestCase):
             assert len(entry.title) > 0
             assert len(entry.artist) > 0
             assert entry.peakPos >= 1 \
-               and entry.peakPos <= 100
+                and entry.peakPos <= 100
             assert entry.lastPos >= 0 \
-               and entry.lastPos <= 100  # 0 means new entry
+                and entry.lastPos <= 100  # 0 means new entry
             assert entry.weeks >= 0
             assert entry.rank >= 1 \
-               and entry.rank <= 100
+                and entry.rank <= 100
             assert re.match(VALID_CHANGE_REGEX, entry.change)
             assert entry.spotifyID is not None
             assert entry.spotifyLink == '' \
@@ -71,12 +73,26 @@ class Hot100QuantizationTest(unittest.TestCase):
 
     def setUp(self):
         dates = ['2016-07-0%d' % x for x in range(1, 8)]  # 7/1/16 to 7/7/16
-        self.charts = [billboard.ChartData('hot-100', date=date, fetch=False) for date in dates]
+        self.charts = [billboard.ChartData(
+            'hot-100', date=date, fetch=False) for date in dates]
 
     def test_correct_fields(self):
         dates = [chart.date for chart in self.charts]
-        reference_dates = list(chain(repeat('2016-07-02', 2), repeat('2016-07-09', 5)))
+        reference_dates = list(
+            chain(repeat('2016-07-02', 2), repeat('2016-07-09', 5)))
         assert dates == reference_dates
+
+
+class DatetimeTest(unittest.TestCase):
+    """Checks that ChartData correctly handles datetime objects as the
+    date parameter.
+    """
+
+    def setUp(self):
+        self.chart = billboard.ChartData('hot-100', datetime.date(2016, 7, 8))
+
+    def test_successful_load(self):
+        self.assertTrue(len(self.chart) > 0)
 
 
 class InvalidDateTest(unittest.TestCase):
@@ -85,12 +101,31 @@ class InvalidDateTest(unittest.TestCase):
     """
 
     def setUp(self):
-        self.chart = billboard.ChartData('hot-100', date='2016-02-12', quantize=False)
+        self.chart = billboard.ChartData(
+            'hot-100', date='2016-02-12', quantize=False)
 
     def test_correct_entries(self):
         assert len(self.chart) == 0
 
 
+<<<<<<< HEAD
+=======
+class MissingSpotifyButtonTest(unittest.TestCase):
+    """Checks that the ChartData object created when there is no green Spotify
+    button has no spotifyID/spotifyLink. This test may break if the song used
+    below is added to Spotify.
+    """
+
+    def setUp(self):
+        self.chart = billboard.ChartData('hot-100', date='2014-01-11')
+
+    def test_correct_entries(self):
+        mine = self.chart[81]  # "Mine" by Beyonce ft. Drake
+        assert mine.spotifyID == '' and mine.spotifyLink == ''
+        assert all(self.chart[i] for i in range(100) if i != 81)
+
+
+>>>>>>> f9eb1ab... chartdata now accepts datetime.date as date parameter; unit test
 def get_test_dir():
     """Returns the name of the directory containing this test file.
     """


### PR DESCRIPTION
Seemed silly to not accept `date` objects off the bat. Now you can loop through dates without casting to strings, for what it's worth.