### PR TITLE
Remove Spotify/video fields, quantization, "change", and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,36 +33,35 @@ Now we can look at the chart entries, which are of type `ChartEntry` and have at
 ```Python
 >>> song = chart[0]  # Get no. 1 song on chart
 >>> song.title
-u'One Dance'
+u'Despacito'
 >>> song.artist
-u'Drake Featuring WizKid & Kyla'
+u'Luis Fonsi & Daddy Yankee Featuring Justin Bieber'
 >>> song.weeks  # Number of weeks on chart
-15
->>> song.spotifyID
-u'11hqMWwX7sF3sOGdtijofF'
+30
 ```
 
 We can also `print` the entire chart:
 
 ```
 >>> print chart
-hot-100 chart (current)
------------------------
-1. 'One Dance' by Drake Featuring WizKid & Kyla (0)
-2. 'Can't Stop The Feeling!' by Justin Timberlake (0)
-3. 'Cheap Thrills' by Sia Featuring Sean Paul (+2)
-# ... 97 more lines
+hot-100 chart from 2017-08-26
+-----------------------------
+1. 'Despacito' by Luis Fonsi & Daddy Yankee Featuring Justin Bieber
+2. 'Wild Thoughts' by DJ Khaled Featuring Rihanna & Bryson Tiller
+3. 'Unforgettable' by French Montana Featuring Swae Lee
+4. 'Believer' by Imagine Dragons
+# ...
 ```
 
-Full documentation
-------------------
+Guide
+-----
 
 ### Downloading a chart
 
 Use the `ChartData` constructor to download a chart:
 
 ```Python
-ChartData(name, date=None, fetch=True, all=False, quantize=True)
+ChartData(name, date=None, fetch=True)
 ```
 
 The arguments are:
@@ -70,8 +69,6 @@ The arguments are:
 * `name` &ndash; The chart name, e.g. `'hot-100'` or `'pop-songs'`. You can browse the [Charts page](http://www.billboard.com/charts) on Billboard.com to find valid chart names; the URL of a chart will look like `http://www.billboard.com/charts/CHART-NAME` ([example](http://www.billboard.com/charts/artist-100)). Almost any chart should work; the only chart known not to work is `spotify-rewind`.
 * `date` &ndash; The chart date as a string, in YYYY-MM-DD format. By default, the latest chart is fetched.
 * `fetch` &ndash; A boolean indicating whether to fetch the chart data from Billboard.com immediately (at instantiation time). If `False`, the chart data can be populated at a later time using the `fetchEntries()` method.
-* `all` &ndash; Deprecated; has no effect.
-* `quantize` &ndash; A boolean indicating whether to round the `date` parameter to the nearest date with a chart.
 
 ### Walking through chart dates
 
@@ -95,25 +92,15 @@ For convenience, `chart[x]` is equivalent to `chart.entries[x]`, and `ChartData`
 A chart entry (typically a single track) is of type `ChartEntry`. A `ChartEntry` instance has the following attributes:
 
 * `title` &ndash; The title of the track.
-* `artist` &ndash; The name of the artist, as formatted on Billboard.com. If there are multiple artists and/or featured artists, they will all be included in this string.
-* `peakPos` &ndash; The track's peak position on the chart, as an int.
-* `lastPos` &ndash; The track's position on the previous week's chart, as an int. This value is 0 if the track has never been on the chart before.
-* `weeks` &ndash; The number of weeks the track has been on the chart. This value is 1 if the track is new on the chart.
+* `artist` &ndash; The name of the artist, as formatted on Billboard.com.
+* `peakPos` &ndash; The track's peak position on the chart at any point in time, including future dates, as an int (or `None` if the chart does not include this information).
+* `lastPos` &ndash; The track's position on the previous week's chart, as an int (or `None` if the chart does not include this information). This value is 0 if the track was not on the previous week's chart.
+* `weeks` &ndash; The number of weeks the track has been or was on the chart, including future dates (up until the present time).
 * `rank` &ndash; The track's current position on the chart.
-* `change` &ndash; A string indicating how the track's position has changed since the previous week. This may be one of the following:
-  * A signed integer like +4, -1, or 0, indicating the difference between the track's current position and its position on the previous week's chart.
-  * 'Hot Shot Debut', which means track is the highest-rated track that is completely new to the chart.
-  * 'New', which means the track is completely new to the chart, yet not the highest rated new track.
-  * 'Re-Entry', which means the track is re-entering the chart after leaving it for at least a week.
-* `spotifyID` &ndash; The Spotify ID of the track, or an empty string if it was not provided. This can be used to access more information about the track via the [Spotify Web API](https://developer.spotify.com/web-api/get-tr ack/).
-* `spotifyLink` &ndash; The Spotify embed URL of the track, generated from the spotifyID. Will be an empty string if no such ID was provided.
-* `videoLink` &ndash; The video URL of the track. Will be an empty string if no such URL was provided.
-
-
 
 ### More resources
 
-For additional documentation, take a look at the source code for `billboard.py`, or use Python's interactive `help` feature.
+For additional documentation, look at the file `billboard.py`, or use Python's interactive `help` feature.
 
 If you're stuck or confused: This is a small project, so you can also just email me (Allen). My contact info is on my profile page.
 
@@ -124,7 +111,10 @@ Found a bug? Create an issue [here](https://github.com/guoguo12/billboard-charts
 
 Pull requests are welcome! Please adhere to the following style guidelines:
 
-* In general, follow [PEP 8](https://www.python.org/dev/peps/pep-0008/). You may ignore E501 ("line too long") and E127 ("continuation line over-indented for visual indent") if following them would detract from the readability of the code. Use your best judgement!
+* In general, follow [PEP 8](https://www.python.org/dev/peps/pep-0008/). You may ignore the following rules if following them would decrease readability:
+    * E127 ("continuation line over-indented for visual indent")
+    * E221 ("multiple spaces before operator")
+    * E501 ("line too long")
 * We use `mixedCase` for variable names.
 * All-uppercase words remain all-uppercase when they appear at the end of variable names (e.g. `downloadHTML` not `downloadHtml`).
 

--- a/examples/top-singles-playlist/README.md
+++ b/examples/top-singles-playlist/README.md
@@ -1,5 +1,7 @@
 # Example: Top Singles Playlist
 
+**Note: This example no longer works, as of [#22](https://github.com/guoguo12/billboard-charts/pull/22).**
+
 In this example, we'll create a Spotify playlist containing the past 100 songs that have reached the top spot on the Hot 100. We'll be using billboard.py and [Spotipy](https://spotipy.readthedocs.org/), which is a wrapper around the [Spotify Web API](https://developer.spotify.com/web-api/).
 
 To view the example, see `run.py`.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='billboard.py',
-      version='3.0.2',
+      version='4.0.0',
       description='Unofficial Python API for accessing Billboard.com charts',
       author='Allen Guo',
       author_email='guoguo12@gmail.com',

--- a/tests/2015-11-28-output.txt
+++ b/tests/2015-11-28-output.txt
@@ -1,102 +1,102 @@
 hot-100 chart from 2015-11-28
 -----------------------------
-1. 'Hello' by Adele (0)
-2. 'Hotline Bling' by Drake (0)
-3. 'Sorry' by Justin Bieber (+1)
-4. 'The Hills' by The Weeknd (-1)
-5. 'Stitches' by Shawn Mendes (+1)
-6. 'What Do You Mean?' by Justin Bieber (-1)
-7. '679' by Fetty Wap Featuring Remy Boyz (+2)
-8. 'Wildest Dreams' by Taylor Swift (0)
-9. 'Like I'm Gonna Lose You' by Meghan Trainor Featuring John Legend (+1)
-10. 'Ex's & Oh's' by Elle King (+2)
-11. 'Here' by Alessia Cara (+2)
-12. 'Can't Feel My Face' by The Weeknd (+2)
-13. 'Focus' by Ariana Grande (-6)
-14. 'Same Old Love' by Selena Gomez (+3)
-15. 'On My Mind' by Ellie Goulding (+3)
-16. 'Jumpman' by Drake & Future (0)
-17. 'Locked Away' by R. City Featuring Adam Levine (-6)
-18. 'Watch Me' by Silento (-3)
-19. 'Lean On' by Major Lazer & DJ Snake Featuring M0 (0)
-20. 'Tennessee Whiskey' by Chris Stapleton (+3)
-21. 'Renegades' by X Ambassadors (-1)
-22. 'Trap Queen' by Fetty Wap (+2)
-23. 'Hit The Quan' by iLoveMemphis (-1)
-24. 'Antidote' by Travi$ Scott (+3)
-25. 'Die A Happy Man' by Thomas Rhett (+3)
-26. 'Good For You' by Selena Gomez Featuring A$AP Rocky (-1)
-27. 'I'll Show You' by Justin Bieber (+24)
-28. 'White Iverson' by Post Malone (+8)
-29. 'Drag Me Down' by One Direction (-3)
-30. 'Downtown' by Macklemore & Ryan Lewis Featuring Eric Nally, Melle Mel, Kool Moe Dee & Grandmaster Caz (-9)
-31. 'Where Ya At' by Future Featuring Drake (-1)
-32. 'Confident' by Demi Lovato (0)
-33. 'See You Again' by Wiz Khalifa Featuring Charlie Puth (+1)
-34. 'Cheerleader' by OMI (-3)
-35. 'My Way' by Fetty Wap Featuring Monty (0)
-36. 'Uptown Funk!' by Mark Ronson Featuring Bruno Mars (+1)
-37. 'Photograph' by Ed Sheeran (-4)
-38. 'How Deep Is Your Love' by Calvin Harris & Disciples (-9)
-39. 'Shut Up And Dance' by WALK THE MOON (-1)
-40. 'Perfect' by One Direction (+4)
-41. 'Again' by Fetty Wap (-2)
-42. 'Don't' by Bryson Tiller (+11)
-43. 'Break Up In A Small Town' by Sam Hunt (-1)
-44. 'I'm Comin' Over' by Chris Young (+3)
-45. 'Thinking Out Loud' by Ed Sheeran (-4)
-46. 'Smoke Break' by Carrie Underwood (+3)
-47. 'Fight Song' by Rachel Platten (-7)
-48. 'Lay It All On Me' by Rudimental Featuring Ed Sheeran (+11)
-49. 'Where Are U Now' by Skrillex & Diplo With Justin Bieber (-3)
-50. 'No Role Modelz' by J. Cole (+6)
-51. 'Burning House' by Cam (+4)
-52. 'Strip It Down' by Luke Bryan (-9)
-53. 'Break Up With Him' by Old Dominion (-5)
-54. 'Back Up' by DeJ Loaf Featuring Big Sean (0)
-55. 'Adventure Of A Lifetime' by Coldplay (Hot Shot Debut)
-56. 'Back To Back' by Drake (-4)
-57. 'Say It' by Tory Lanez (+7)
-58. 'Come Get Her' by Rae Sremmurd (0)
-59. 'Gonna' by Blake Shelton (+4)
-60. 'Let Me See Ya Girl' by Cole Swindell (+1)
-61. 'Bet You Can't Do It Like Me' by DLOW (New)
-62. 'Nothin' Like You' by Dan + Shay (0)
-63. 'Blase' by Ty Dolla $ign Featuring Future & Rae Sremmurd (+3)
-64. 'Roses' by The Chainsmokers Featuring ROZES (+4)
-65. 'History' by One Direction (New)
-66. 'The Fix' by Nelly Featuring Jeremih (+3)
-67. 'Love Myself' by Hailee Steinfeld (-7)
-68. 'Liquor' by Chris Brown (-1)
-69. 'Stressed Out' by twenty one pilots (+2)
-70. 'Big Rings' by Drake & Future (0)
-71. 'Hide Away' by Daya (+5)
-72. 'Stay A Little Longer' by Brothers Osborne (+1)
-73. 'Writing's On The Wall' by Sam Smith (Re-Entry)
-74. 'Gonna Know We Were Here' by Jason Aldean (+5)
-75. 'Alive' by Sia (Re-Entry)
-76. 'Exchange' by Bryson Tiller (+10)
-77. 'I Got The Boy' by Jana Kramer (+1)
-78. 'Right Hand' by Drake (-4)
-79. 'Anything Goes' by Florida Georgia Line (-14)
-80. 'Top Of The World' by Tim McGraw (+2)
-81. 'Cool For The Summer' by Demi Lovato (-9)
-82. 'Comfortable' by K Camp (-5)
-83. 'Save It For A Rainy Day' by Kenny Chesney (-8)
-84. 'RGF Island' by Fetty Wap (-3)
-85. 'Diamonds Dancing' by Drake & Future (-5)
-86. 'Cake By The Ocean' by DNCE (-1)
-87. 'Traveller' by Chris Stapleton (New)
-88. 'Halo' by Jordan Smith (New)
-89. 'Me, Myself & I' by G-Eazy x Bebe Rexha (-6)
-90. 'I Love This Life' by LoCash (-2)
-91. 'WTF (Where They From)' by Missy Elliott Featuring Pharrell Williams (New)
-92. 'Dibs' by Kelsea Ballerini (-2)
-93. '$ave Dat Money' by Lil Dicky Featuring Fetty Wap & Rich Homie Quan (-4)
-94. 'Stand By You' by Rachel Platten (New)
-95. 'Hold My Hand' by Jess Glynne (-8)
-96. 'My House' by Flo Rida (New)
-97. 'Ginza' by J Balvin (-6)
-98. 'Play No Games' by Big Sean Featuring Chris Brown & Ty Dolla $ign (-5)
-99. 'Levels' by Nick Jonas (-15)
-100. 'Beautiful Drug' by Zac Brown Band (-5)
+1. 'Hello' by Adele
+2. 'Hotline Bling' by Drake
+3. 'Sorry' by Justin Bieber
+4. 'The Hills' by The Weeknd
+5. 'Stitches' by Shawn Mendes
+6. 'What Do You Mean?' by Justin Bieber
+7. '679' by Fetty Wap Featuring Remy Boyz
+8. 'Wildest Dreams' by Taylor Swift
+9. 'Like I'm Gonna Lose You' by Meghan Trainor Featuring John Legend
+10. 'Ex's & Oh's' by Elle King
+11. 'Here' by Alessia Cara
+12. 'Can't Feel My Face' by The Weeknd
+13. 'Focus' by Ariana Grande
+14. 'Same Old Love' by Selena Gomez
+15. 'On My Mind' by Ellie Goulding
+16. 'Jumpman' by Drake & Future
+17. 'Locked Away' by R. City Featuring Adam Levine
+18. 'Watch Me' by Silento
+19. 'Lean On' by Major Lazer & DJ Snake Featuring MO
+20. 'Tennessee Whiskey' by Chris Stapleton
+21. 'Renegades' by X Ambassadors
+22. 'Trap Queen' by Fetty Wap
+23. 'Hit The Quan' by iLoveMemphis
+24. 'Antidote' by Travis Scott
+25. 'Die A Happy Man' by Thomas Rhett
+26. 'Good For You' by Selena Gomez Featuring A$AP Rocky
+27. 'I'll Show You' by Justin Bieber
+28. 'White Iverson' by Post Malone
+29. 'Drag Me Down' by One Direction
+30. 'Downtown' by Macklemore & Ryan Lewis Featuring Eric Nally, Melle Mel, Kool Moe Dee & Grandmaster Caz
+31. 'Where Ya At' by Future Featuring Drake
+32. 'Confident' by Demi Lovato
+33. 'See You Again' by Wiz Khalifa Featuring Charlie Puth
+34. 'Cheerleader' by OMI
+35. 'My Way' by Fetty Wap Featuring Monty
+36. 'Uptown Funk!' by Mark Ronson Featuring Bruno Mars
+37. 'Photograph' by Ed Sheeran
+38. 'How Deep Is Your Love' by Calvin Harris & Disciples
+39. 'Shut Up And Dance' by WALK THE MOON
+40. 'Perfect' by One Direction
+41. 'Again' by Fetty Wap
+42. 'Don't' by Bryson Tiller
+43. 'Break Up In A Small Town' by Sam Hunt
+44. 'I'm Comin' Over' by Chris Young
+45. 'Thinking Out Loud' by Ed Sheeran
+46. 'Smoke Break' by Carrie Underwood
+47. 'Fight Song' by Rachel Platten
+48. 'Lay It All On Me' by Rudimental Featuring Ed Sheeran
+49. 'Where Are U Now' by Skrillex & Diplo With Justin Bieber
+50. 'No Role Modelz' by J. Cole
+51. 'Burning House' by Cam
+52. 'Strip It Down' by Luke Bryan
+53. 'Break Up With Him' by Old Dominion
+54. 'Back Up' by DeJ Loaf Featuring Big Sean
+55. 'Adventure Of A Lifetime' by Coldplay
+56. 'Back To Back' by Drake
+57. 'Say It' by Tory Lanez
+58. 'Come Get Her' by Rae Sremmurd
+59. 'Gonna' by Blake Shelton
+60. 'Let Me See Ya Girl' by Cole Swindell
+61. 'Do It Like Me' by DLOW
+62. 'Nothin' Like You' by Dan + Shay
+63. 'Blase' by Ty Dolla $ign Featuring Future & Rae Sremmurd
+64. 'Roses' by The Chainsmokers Featuring Rozes
+65. 'History' by One Direction
+66. 'The Fix' by Nelly Featuring Jeremih
+67. 'Love Myself' by Hailee Steinfeld
+68. 'Liquor' by Chris Brown
+69. 'Stressed Out' by twenty one pilots
+70. 'Big Rings' by Drake & Future
+71. 'Hide Away' by Daya
+72. 'Stay A Little Longer' by Brothers Osborne
+73. 'Writing's On The Wall' by Sam Smith
+74. 'Gonna Know We Were Here' by Jason Aldean
+75. 'Alive' by Sia
+76. 'Exchange' by Bryson Tiller
+77. 'I Got The Boy' by Jana Kramer
+78. 'Right Hand' by Drake
+79. 'Anything Goes' by Florida Georgia Line
+80. 'Top Of The World' by Tim McGraw
+81. 'Cool For The Summer' by Demi Lovato
+82. 'Comfortable' by K Camp
+83. 'Save It For A Rainy Day' by Kenny Chesney
+84. 'RGF Island' by Fetty Wap
+85. 'Diamonds Dancing' by Drake & Future
+86. 'Cake By The Ocean' by DNCE
+87. 'Traveller' by Chris Stapleton
+88. 'Halo' by Jordan Smith
+89. 'Me, Myself & I' by G-Eazy x Bebe Rexha
+90. 'I Love This Life' by LOCASH
+91. 'WTF (Where They From)' by Missy Elliott Featuring Pharrell Williams
+92. 'Dibs' by Kelsea Ballerini
+93. '$ave Dat Money' by Lil Dicky Featuring Fetty Wap & Rich Homie Quan
+94. 'Stand By You' by Rachel Platten
+95. 'Hold My Hand' by Jess Glynne
+96. 'My House' by Flo Rida
+97. 'Ginza' by J Balvin
+98. 'Play No Games' by Big Sean Featuring Chris Brown & Ty Dolla $ign
+99. 'Levels' by Nick Jonas
+100. 'Beautiful Drug' by Zac Brown Band

--- a/tests/test_billboard.py
+++ b/tests/test_billboard.py
@@ -7,8 +7,6 @@ import datetime
 
 import billboard
 
-VALID_CHANGE_REGEX = r'^(\+\d{1,2}|\-\d{1,2}|0|Hot Shot Debut|New|Re-Entry)$'
-
 
 class CurrentHot100Test(unittest.TestCase):
     """Checks that the ChartData object for the current Hot 100 chart
@@ -20,7 +18,6 @@ class CurrentHot100Test(unittest.TestCase):
 
     def test_correct_fields(self):
         assert self.chart.date is not None
-        assert self.chart.latest is True
         assert list(sorted(entry.rank for entry in self.chart)
                     ) == list(range(1, 101))
 
@@ -36,14 +33,10 @@ class CurrentHot100Test(unittest.TestCase):
             assert entry.weeks >= 0
             assert entry.rank >= 1 \
                 and entry.rank <= 100
-            assert re.match(VALID_CHANGE_REGEX, entry.change)
-            assert entry.spotifyID is not None
-            assert entry.spotifyLink == '' \
-                or 'embed.spotify.com' in entry.spotifyLink
             assert repr(entry)
 
     def test_valid_json(self):
-        assert json.loads(self.chart.to_JSON())
+        assert json.loads(self.chart.json())
 
 
 class HistoricalHot100Test(CurrentHot100Test):
@@ -57,7 +50,6 @@ class HistoricalHot100Test(CurrentHot100Test):
 
     def test_correct_fields(self):
         assert self.chart.date == '2015-11-28'
-        assert self.chart.latest is False
         assert self.chart.previousDate == '2015-11-21'
 
     def test_correct_entries(self):
@@ -77,7 +69,6 @@ class CurrentGreatestHot100SinglesTest(unittest.TestCase):
 
     def test_correct_fields(self):
         assert self.chart.date is None
-        assert self.chart.latest is True
         assert list(sorted(entry.rank for entry in self.chart)
                     ) == list(range(1, 101))
 
@@ -91,30 +82,10 @@ class CurrentGreatestHot100SinglesTest(unittest.TestCase):
             assert entry.weeks is None
             assert entry.rank >= 1 \
                 and entry.rank <= 100
-            assert entry.change is None
-            assert entry.spotifyID == ''
-            assert entry.spotifyLink == ''
             assert repr(entry)
 
     def test_valid_json(self):
-        assert json.loads(self.chart.to_JSON())
-
-
-class Hot100QuantizationTest(unittest.TestCase):
-    """Checks that the date quantization feature for ChartData
-    functions correctly.
-    """
-
-    def setUp(self):
-        dates = ['2016-07-0%d' % x for x in range(1, 8)]  # 7/1/16 to 7/7/16
-        self.charts = [billboard.ChartData(
-            'hot-100', date=date, fetch=False) for date in dates]
-
-    def test_correct_fields(self):
-        dates = [chart.date for chart in self.charts]
-        reference_dates = list(
-            chain(repeat('2016-07-02', 2), repeat('2016-07-09', 5)))
-        assert dates == reference_dates
+        assert json.loads(self.chart.json())
 
 
 class DatetimeTest(unittest.TestCase):
@@ -127,19 +98,6 @@ class DatetimeTest(unittest.TestCase):
 
     def test_successful_load(self):
         self.assertTrue(len(self.chart) > 0)
-
-
-class InvalidDateTest(unittest.TestCase):
-    """Checks that the ChartData object created when the date is
-    invalid (and quantization is turned off) has no entries.
-    """
-
-    def setUp(self):
-        self.chart = billboard.ChartData(
-            'hot-100', date='2016-02-12', quantize=False)
-
-    def test_correct_entries(self):
-        assert len(self.chart) == 0
 
 
 def get_test_dir():

--- a/tests/test_billboard.py
+++ b/tests/test_billboard.py
@@ -58,10 +58,25 @@ class HistoricalHot100Test(CurrentHot100Test):
             assert str(self.chart) == reference.read()
 
 
+class DateRoundingTest(unittest.TestCase):
+    """Checks that the Billboard website is rounding dates correctly: it should
+    round up to the nearest date on which a chart was published.
+    """
+
+    def setUp(self):
+        self.chart = billboard.ChartData('hot-100', date='1000-10-10')
+
+    def test_correct_fields(self):
+        assert self.chart.date == '1958-08-04'  # The first Hot 100 chart
+
+
 class CurrentGreatestHot100SinglesTest(unittest.TestCase):
     """Checks that the ChartData object for the current
     greatest-hot-100-singles chart has all valid fields, and that its entries
     also have valid fields.
+
+    The greatest-hot-100-singles chart is special in that it does not provide
+    peak/last position or weeks-on-chart data.
     """
 
     def setUp(self):


### PR DESCRIPTION
Some recent changes to the Billboard website:
- It looks like their "peak position" and "weeks on chart" numbers now include future dates. For example, if a song was at no. 100 on Week 1 and then jumped to no. 1 the next week, the "peak position" for the song on the Week 1 chart will be 1.
- They no longer label entries as "New", "Hot-Shot Debut", or "Re-Entry".
- They no longer provide Spotify information (#21).
- They no longer embed Vevo videos (AFAIK).
- They automatically round dates up to the nearest date with a chart (i.e., they now handle what we've been calling "quantization"). So http://www.billboard.com/charts/hot-100/2017-08-17 will show the chart for Saturday, August 19.

Changes:
- Removed Spotify-related fields.
- Removed the `videoLink` field.
- Removed the `change` field. Since there's no more "New" or Hot-Shot Debut" or "Re-Entry", the only notion of "change" that remains is "difference from the previous week's rank", which can be calculated by subtracting `lastPos` from `rank`.
- Removed quantization.
- Renamed the `to_JSON` method to `json` for style consistency.
- Improved error-handling during parsing.
- Improved and updated documentation and tests.

This is a major breaking change. It is not backwards-compatible.

Altogether, this is good because it makes the code much simpler, but it's also a huge bummer because being able to connect with Spotify was an incredibly useful feature. Ah well...