### PR TITLE
Fix artist charts not working

### DIFF
--- a/billboard.py
+++ b/billboard.py
@@ -164,7 +164,8 @@ class ChartData:
             basicInfoSoup = entrySoup.find('div', 'chart-row__title').contents
 
             try:
-                title = basicInfoSoup[1].string.strip()
+                title = basicInfoSoup[1].string or ''
+                title = title.strip()
             except:
                 message = "Failed to parse title"
                 raise BillboardParseException(message)

--- a/billboard.py
+++ b/billboard.py
@@ -54,7 +54,11 @@ class ChartEntry:
     def __repr__(self):
         """Returns a string of the form 'TITLE by ARTIST'.
         """
-        s = u"'%s' by %s" % (self.title, self.artist)
+        if self.title:
+            s = u"'%s' by %s" % (self.title, self.artist)
+        else:
+            s = u"%s" % self.artist
+
         if sys.version_info.major < 3:
             return s.encode(getattr(sys.stdout, 'encoding', '') or 'utf8')
         else:


### PR DESCRIPTION
It looks like artist charts don't work due to trying to parse a title for everything and artists don't have a title. Should fix #20.

I've just changed the title to empty, but this kind of circumvents the exception if `basicInfoSoup[1].string` is always there. I suppose it could be better to parse the artist name as the title or something? Also note that the chart printout has lines like `1. '' by The Beatles` with this change. I suppose we could look to see if `'artist'` is in the chart name and then process based on that.