### PR TITLE
Refactor tests to use unittest assertions

### DIFF
--- a/tests/test_artist_100.py
+++ b/tests/test_artist_100.py
@@ -1,11 +1,11 @@
 import json
 import os
-
+import unittest
 import billboard
 from utils import get_test_dir
 
 
-class TestCurrentArtist100:
+class TestCurrentArtist100(unittest.TestCase):
     """Checks that the ChartData object for the current Artist 100 chart has
     entries and instance variables that are valid and reasonable. Does not test
     whether the data is actually correct.
@@ -17,32 +17,33 @@ class TestCurrentArtist100:
         self.chart = billboard.ChartData('artist-100')
 
     def test_date(self):
-        assert self.chart.date is not None
+        self.assertIsNotNone(self.chart.date)
 
     def test_ranks(self):
         ranks = list(entry.rank for entry in self.chart)
-        assert ranks == list(range(1, 101))
+        self.assertEqual(ranks, list(range(1, 101)))
 
     def test_entries_validity(self):
-        assert len(self.chart) == 100
+        self.assertEqual(len(self.chart), 100)
         for entry in self.chart:
-            assert entry.title == ''  # This chart has no titles
-            assert len(entry.artist) > 0
-            assert 1 <= entry.peakPos <= 100
-            assert 0 <= entry.lastPos <= 100
-            assert entry.weeks >= 0
-            assert 1 <= entry.rank <= 100  # Redundant because of test_ranks
-            assert isinstance(entry.isNew, bool)
+            self.assertEqual(entry.title, '')  # This chart has no titles
+            self.assertTrue(len(entry.artist) > 0)
+            self.assertTrue(1 <= entry.peakPos <= 100)
+            self.assertTrue(0 <= entry.lastPos <= 100)
+            self.assertTrue(entry.weeks >= 0)
+            # Redundant because of test_ranks
+            self.assertTrue(1 <= entry.rank <= 100)
+            self.assertIsInstance(entry.isNew, bool)
 
     def test_entries_consistency(self):
         for entry in self.chart:
             if entry.isNew:
-                assert entry.lastPos == 0
+                self.assertEqual(entry.lastPos, 0)
 
     def test_json(self):
-        assert json.loads(self.chart.json())
+        self.assertTrue(json.loads(self.chart.json()))
         for entry in self.chart:
-            assert json.loads(entry.json())
+            self.assertTrue(json.loads(entry.json()))
 
 
 class TestHistoricalArtist100(TestCurrentArtist100):
@@ -58,12 +59,12 @@ class TestHistoricalArtist100(TestCurrentArtist100):
         self.chart = billboard.ChartData('artist-100', date='2014-07-26')
 
     def test_date(self):
-        assert self.chart.date == '2014-07-26'
-        assert self.chart.previousDate == '2014-07-19'
-        assert self.chart.nextDate == '2014-08-02'
+        self.assertEqual(self.chart.date, '2014-07-26')
+        self.assertEqual(self.chart.previousDate, '2014-07-19')
+        self.assertEqual(self.chart.nextDate, '2014-08-02')
 
     def test_entries_correctness(self):
         reference_path = os.path.join(get_test_dir(),
                                       '2014-07-26-artist-100.txt')
         with open(reference_path) as reference:
-            assert str(self.chart) == reference.read()
+            self.assertEqual(str(self.chart), reference.read())

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,51 +1,50 @@
 import datetime
-
+import unittest
 import billboard
 from nose.tools import raises
 
 
-def test_date_rounding():
-    """Checks that the Billboard website is rounding dates correctly: it should
-    round up to the nearest date on which a chart was published.
-    """
-    chart = billboard.ChartData('hot-100', date='1000-10-10')
-    assert chart.date == '1958-08-04'  # The first Hot 100 chart
+class DateTest(unittest.TestCase):
+    def test_date_rounding(self):
+        """Checks that the Billboard website is rounding dates correctly: it should
+        round up to the nearest date on which a chart was published.
+        """
+        chart = billboard.ChartData('hot-100', date='1000-10-10')
+        self.assertEqual(chart.date, '1958-08-04')  # The first Hot 100 chart
 
-    chart = billboard.ChartData('hot-100', date='1996-07-30')
-    assert chart.date == '1996-08-03'
+        chart = billboard.ChartData('hot-100', date='1996-07-30')
+        self.assertEqual(chart.date, '1996-08-03')
 
+    def test_previous_next(self):
+        """Checks that the date, previousDate, and nextDate attributes are parsed
+        from the HTML, not computed. Specifically, we shouldn't assume charts are
+        always published seven days apart, since (as this example demonstrates)
+        this is not true.
+        """
+        chart = billboard.ChartData('hot-100', date='1962-01-06')
+        self.assertEqual(chart.date, '1962-01-06')
+        self.assertEqual(chart.previousDate, '1961-12-25')
 
-def test_previous_next():
-    """Checks that the date, previousDate, and nextDate attributes are parsed
-    from the HTML, not computed. Specifically, we shouldn't assume charts are
-    always published seven days apart, since (as this example demonstrates)
-    this is not true.
-    """
-    chart = billboard.ChartData('hot-100', date='1962-01-06')
-    assert chart.date == '1962-01-06'
-    assert chart.previousDate == '1961-12-25'
+        chart = billboard.ChartData('hot-100', date='1961-12-25')
+        self.assertEqual(chart.date, '1961-12-25')
+        self.assertEqual(chart.nextDate, '1962-01-06')
 
-    chart = billboard.ChartData('hot-100', date='1961-12-25')
-    assert chart.date == '1961-12-25'
-    assert chart.nextDate == '1962-01-06'
+    def test_datetime_date(self):
+        """Checks that ChartData correctly handles datetime objects as the
+        date parameter.
+        """
+        chart = billboard.ChartData('hot-100', datetime.date(2016, 7, 9))
+        self.assertEqual(len(chart), 100)
+        self.assertEqual(chart.date, '2016-07-09')
 
+    @raises(ValueError)
+    def test_unsupported_date_format(self):
+        """Checks that using an unsupported date format raises an exception."""
+        billboard.ChartData('hot-100', date='07-30-1996')
 
-def test_datetime_date():
-    """Checks that ChartData correctly handles datetime objects as the
-    date parameter.
-    """
-    chart = billboard.ChartData('hot-100', datetime.date(2016, 7, 9))
-    assert len(chart) == 100
-    assert chart.date == '2016-07-09'
-
-
-@raises(ValueError)
-def test_unsupported_date_format():
-    """Checks that using an unsupported date format raises an exception."""
-    billboard.ChartData('hot-100', date='07-30-1996')
-
-
-@raises(ValueError)
-def test_empty_string_date():
-    """Checks that passing an empty string as the date raises an exception."""
-    billboard.ChartData('hot-100', date='')
+    @raises(ValueError)
+    def test_empty_string_date(self):
+        """
+        Checks that passing an empty string as the date raises an exception.
+        """
+        billboard.ChartData('hot-100', date='')

--- a/tests/test_greatest_hot_100_singles.py
+++ b/tests/test_greatest_hot_100_singles.py
@@ -1,9 +1,9 @@
 import json
-
+import unittest
 import billboard
 
 
-class TestCurrentGreatestHot100Singles:
+class TestCurrentGreatestHot100Singles(unittest.TestCase):
     """Checks that the ChartData object for the current Greatest Hot 100
     Singles chart has entries and instance variables that are valid and
     reasonable. Does not test whether the data is actually correct.
@@ -16,24 +16,25 @@ class TestCurrentGreatestHot100Singles:
         self.chart = billboard.ChartData('greatest-hot-100-singles')
 
     def test_date(self):
-        assert self.chart.date is None  # This chart has no dates
+        self.assertIsNone(self.chart.date)  # This chart has no dates
 
     def test_ranks(self):
         ranks = list(entry.rank for entry in self.chart)
-        assert ranks == list(range(1, 101))
+        self.assertEqual(ranks, list(range(1, 101)))
 
     def test_entries_validity(self):
-        assert len(self.chart) == 100
+        self.assertEqual(len(self.chart), 100)
         for entry in self.chart:
-            assert len(entry.title) > 0
-            assert len(entry.artist) > 0
-            assert entry.peakPos is None
-            assert entry.lastPos is None
-            assert entry.weeks is None
-            assert 1 <= entry.rank <= 100  # Redundant because of test_ranks
-            assert isinstance(entry.isNew, bool)
+            self.assertGreater(len(entry.title), 0)
+            self.assertGreater(len(entry.artist), 0)
+            self.assertIsNone(entry.peakPos)
+            self.assertIsNone(entry.lastPos)
+            self.assertIsNone(entry.weeks)
+            # Redundant because of test_ranks
+            self.assertTrue(1 <= entry.rank <= 100)
+            self.assertIsInstance(entry.isNew, bool)
 
     def test_json(self):
-        assert json.loads(self.chart.json())
+        self.assertTrue(json.loads(self.chart.json()))
         for entry in self.chart:
-            assert json.loads(entry.json())
+            self.assertTrue(json.loads(entry.json()))

--- a/tests/test_hot_100.py
+++ b/tests/test_hot_100.py
@@ -1,11 +1,11 @@
 import json
 import os
-
+import unittest
 import billboard
 from utils import get_test_dir
 
 
-class TestCurrentHot100:
+class TestCurrentHot100(unittest.TestCase):
     """Checks that the ChartData object for the current Hot 100 chart has
     entries and instance variables that are valid and reasonable. Does not test
     whether the data is actually correct.
@@ -15,32 +15,33 @@ class TestCurrentHot100:
         self.chart = billboard.ChartData('hot-100')
 
     def test_date(self):
-        assert self.chart.date is not None
+        self.assertIsNotNone(self.chart.date)
 
     def test_ranks(self):
         ranks = list(entry.rank for entry in self.chart)
-        assert ranks == list(range(1, 101))
+        self.assertEqual(ranks, list(range(1, 101)))
 
     def test_entries_validity(self):
-        assert len(self.chart) == 100
+        self.assertEqual(len(self.chart), 100)
         for entry in self.chart:
-            assert len(entry.title) > 0
-            assert len(entry.artist) > 0
-            assert 1 <= entry.peakPos <= 100
-            assert 0 <= entry.lastPos <= 100
-            assert entry.weeks >= 0
-            assert 1 <= entry.rank <= 100  # Redundant because of test_ranks
-            assert isinstance(entry.isNew, bool)
+            self.assertGreater(len(entry.title), 0)
+            self.assertGreater(len(entry.artist), 0)
+            self.assertTrue(1 <= entry.peakPos <= 100)
+            self.assertTrue(0 <= entry.lastPos <= 100)
+            self.assertGreaterEqual(entry.weeks, 0)
+            # Redundant because of test_ranks
+            self.assertTrue(1 <= entry.rank <= 100)
+            self.assertIsInstance(entry.isNew, bool)
 
     def test_entries_consistency(self):
         for entry in self.chart:
             if entry.isNew:
-                assert entry.lastPos == 0
+                self.assertEqual(entry.lastPos, 0)
 
     def test_json(self):
-        assert json.loads(self.chart.json())
+        self.assertTrue(json.loads(self.chart.json()))
         for entry in self.chart:
-            assert json.loads(entry.json())
+            self.assertTrue(json.loads(entry.json()))
 
 
 class TestHistoricalHot100(TestCurrentHot100):
@@ -56,11 +57,11 @@ class TestHistoricalHot100(TestCurrentHot100):
         self.chart = billboard.ChartData('hot-100', date='2015-11-28')
 
     def test_date(self):
-        assert self.chart.date == '2015-11-28'
-        assert self.chart.previousDate == '2015-11-21'
-        assert self.chart.nextDate == '2015-12-05'
+        self.assertEqual(self.chart.date, '2015-11-28')
+        self.assertEqual(self.chart.previousDate, '2015-11-21')
+        self.assertEqual(self.chart.nextDate, '2015-12-05')
 
     def test_entries_correctness(self):
         reference_path = os.path.join(get_test_dir(), '2015-11-28-hot-100.txt')
         with open(reference_path) as reference:
-            assert str(self.chart) == reference.read()
+            self.assertEqual(str(self.chart), reference.read())

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,4 +1,5 @@
 import billboard
+import unittest
 from nose.tools import raises
 from requests.exceptions import ConnectionError
 


### PR DESCRIPTION
It appears at some point we moved away from using the `unittest` library, which provides handy assertion methods that make test failures easier to read. Compare the output from the following test case failures:

```
assert chart.date == 10
AssertionError:
```
```
self.assertEqual(chart.date, 10)
AssertionError: '1961-12-25' != 10
```

This should hopefully make further refactoring easier as unexpected bugs arise.