### PR TITLE
Add repr printing format

### DIFF
--- a/billboard.py
+++ b/billboard.py
@@ -59,6 +59,12 @@ class ChartEntry:
         self.isNew = isNew
 
     def __repr__(self):
+        return '{}.{}(title={!r}, artist={!r})'.format(self.__class__.__module__,
+                                                       self.__class__.__name__,
+                                                       self.title,
+                                                       self.artist)
+
+    def __str__(self):
         """Returns a string of the form 'TITLE by ARTIST'.
         """
         if self.title:
@@ -127,6 +133,11 @@ class ChartData:
             self.fetchEntries()
 
     def __repr__(self):
+        return '{}.{}({!r}, {!r})'.format(self.__class__.__module__,
+                                          self.__class__.__name__,
+                                          self.name, self.date)
+
+    def __str__(self):
         """Returns the chart as a human-readable string (typically multi-line).
         """
         if not self.date:


### PR DESCRIPTION
Update string conversion functions to match descriptions in [official Python documentation](https://docs.python.org/2/library/functions.html).

New behavior:

    > chart = billboard.ChartData('hot-100', date='1996-07-30')

    > chart
    billboard.ChartData('hot-100', date='1996-08-03')

    > print chart
    hot-100 chart from 1996-08-03
    -----------------------------
    1. ‘Macarena (Bayside Boys Mix)’ by Los Del Rio
    ...
    
    > chart[0]
    billboard.ChartEntry(title=u'Macarena (Bayside Boys Mix)', artist=u'Los Del Rio')

    > print chart[0]
    'Macarena (Bayside Boys Mix)' by Los Del Rio

Note that the `repr` of a `ChartEntry` is not round-trippable; the `__init__` requires all the attributes (`title, artist, peakPos, lastPos, weeks, rank, isNew`). To keep the `repr` explicit but readable, I'm only including title and artist.