### PR TITLE
Add tests for repr

### DIFF
--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,19 @@
+import billboard
+import unittest
+import six
+
+
+class TestFormatting(unittest.TestCase):
+    """Checks consistency of output strings."""
+
+    def test_repr_chart(self):
+        chart = billboard.ChartData('hot-100', date='1996-07-30')
+        self.assertEqual(repr(chart), "billboard.ChartData('hot-100', date='1996-08-03')")
+
+    def test_repr_entry(self):
+        """Checks absense of unicode characters in song titles and artists."""
+        chart = billboard.ChartData('latin-pop-songs', date='1994-10-15')
+        self.assertEqual(repr(chart[0]),
+                         "billboard.ChartEntry(title={!r}, artist={!r})".format(
+                             six.text_type('El Dia Que Me Quieras'),
+                             six.text_type('Luis Miguel')))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
 envlist = py27,py34
 [testenv]
-deps=nose
+deps=
+    nose
+    six
 commands=nosetests


### PR DESCRIPTION
Added a new file `test_formatting.py` that contains tests for the new `repr` functionality. Requires new dependency `six` for testing unicode string representations in both Python 2 and 3.

Currently, Billboard does not use any unicode-specific characters in their charts. To test that this behavior does not change, I checked the first (and only) entry in `latin-pop-songs/1994-10-15`:

`billboard.ChartEntry(title="El Dia Que Me Quieras", artist="Luis Miguel")`.

If Billboard ever switches to unicode-specific characters, the i in "Dia" **should** be an accented í.

#43