### PR TITLE
#49, #50 isNew and weeks count fix

### DIFF
--- a/billboard.py
+++ b/billboard.py
@@ -28,6 +28,7 @@ _TOP_TITLE_SELECTOR = 'div.chart-number-one__title'
 _TOP_ARTIST_SELECTOR = 'div.chart-number-one__artist'
 _TOP_LAST_POS_SELECTOR = 'div.chart-number-one__last-week'
 _TOP_WEEKS_SELECTOR = 'div.chart-number-one__weeks-on-chart'
+_NUMBER_ONE_NEW_SELECTOR = 'img.chart-number-one__stats-cell-new'
 _ENTRY_LIST_SELECTOR = 'div.chart-list-item'
 _ENTRY_TITLE_ATTR = 'data-title'
 _ENTRY_ARTIST_ATTR = 'data-artist'
@@ -240,15 +241,21 @@ class ChartData:
 
         if self.date:
             topPeakPos = 1
+            topIsNew = False
             try:
                 topLastPos = int(soup.select_one(_TOP_LAST_POS_SELECTOR).string.strip())
             except:
-                # if there is no div with class div.chart-number-one__last-week, that means it was the top song the prior week
-                topLastPos = 1
+                # if there is no div with class div.chart-number-one__last-week,
+                # that means it was the top song the prior week, unless there is
+                # a NEW badge
+                if (soup.select_one(_NUMBER_ONE_NEW_SELECTOR) is not None):
+                    topIsNew = True
+                    topLastPos = 0
+                else:
+                    topLastPos = 1
 
             topWeeksElement = soup.select_one(_TOP_WEEKS_SELECTOR)
             topWeeks = int(topWeeksElement.string.strip()) if topWeeksElement is not None else 0
-            topIsNew = True if topWeeks == 0 else False
         else:
             topPeakPos = topLastPos = topWeeks = None
             topIsNew = False
@@ -295,7 +302,8 @@ class ChartData:
                 peakPos = rank if peakPos == 0 else peakPos
                 lastPos = getPositionRowValue(_LAST_POS_FORMAT)
                 weeks = getPositionRowValue(_WEEKS_ON_CHART_FORMAT)
-                isNew = True if weeks == 0 else False
+                weeks = weeks if weeks != 0 else 1
+                isNew = True if weeks == 1 else False
             else:
                 peakPos = lastPos = weeks = None
                 isNew = False

--- a/tests/test_artist_100.py
+++ b/tests/test_artist_100.py
@@ -30,7 +30,7 @@ class TestCurrentArtist100(unittest.TestCase):
             self.assertGreater(len(entry.artist), 0)
             self.assertTrue(1 <= entry.peakPos <= 100)
             self.assertTrue(0 <= entry.lastPos <= 100)
-            self.assertGreaterEqual(entry.weeks, 0)
+            self.assertGreaterEqual(entry.weeks, 1)
             # Redundant because of test_ranks
             self.assertTrue(1 <= entry.rank <= 100)
             self.assertIsInstance(entry.isNew, bool)
@@ -38,7 +38,7 @@ class TestCurrentArtist100(unittest.TestCase):
     def test_entries_consistency(self):
         for entry in self.chart:
             if entry.isNew:
-                self.assertEqual(entry.lastPos, 0)
+                self.assertEqual(0, entry.lastPos)
 
     def test_json(self):
         self.assertTrue(json.loads(self.chart.json()))

--- a/tests/test_digital_albums.py
+++ b/tests/test_digital_albums.py
@@ -28,7 +28,7 @@ class TestCurrentDigitalAlbums(unittest.TestCase):
             self.assertGreater(len(entry.artist), 0)
             self.assertTrue(1 <= entry.peakPos <= 100)
             self.assertTrue(0 <= entry.lastPos <= 100)
-            self.assertGreaterEqual(entry.weeks, 0)
+            self.assertGreaterEqual(entry.weeks, 1)
             # Redundant because of test_ranks
             self.assertTrue(1 <= entry.rank <= 25)
             self.assertIsInstance(entry.isNew, bool)
@@ -36,7 +36,7 @@ class TestCurrentDigitalAlbums(unittest.TestCase):
     def test_entries_consistency(self):
         for entry in self.chart:
             if entry.isNew:
-                self.assertEqual(entry.lastPos, 0)
+                self.assertEqual(0, entry.lastPos)
 
     def test_json(self):
         self.assertTrue(json.loads(self.chart.json()))

--- a/tests/test_hot_100.py
+++ b/tests/test_hot_100.py
@@ -28,7 +28,7 @@ class TestCurrentHot100(unittest.TestCase):
             self.assertGreater(len(entry.artist), 0)
             self.assertTrue(1 <= entry.peakPos <= 100)
             self.assertTrue(0 <= entry.lastPos <= 100)
-            self.assertGreaterEqual(entry.weeks, 0)
+            self.assertGreaterEqual(entry.weeks, 1)
             # Redundant because of test_ranks
             self.assertTrue(1 <= entry.rank <= 100)
             self.assertIsInstance(entry.isNew, bool)
@@ -36,7 +36,7 @@ class TestCurrentHot100(unittest.TestCase):
     def test_entries_consistency(self):
         for entry in self.chart:
             if entry.isNew:
-                self.assertEqual(entry.lastPos, 0)
+                self.assertEqual(0, entry.lastPos)
 
     def test_json(self):
         self.assertTrue(json.loads(self.chart.json()))
@@ -65,3 +65,17 @@ class TestHistoricalHot100(TestCurrentHot100):
         reference_path = os.path.join(get_test_dir(), '2015-11-28-hot-100.txt')
         with open(reference_path) as reference:
             self.assertEqual(str(self.chart), reference.read())
+        
+    def test_debut_number_1(self):
+        chart = billboard.ChartData('hot-100', '2018-11-17')
+        ari = chart.entries[0]
+        self.assertTrue(ari.isNew)
+        self.assertEqual(0, ari.lastPos)
+    
+    def test_debut_weeks(self):
+        chart = billboard.ChartData('hot-100', '2018-11-17')
+        metro_boomin = chart.entries[37]
+        self.assertTrue(metro_boomin.isNew)
+        self.assertEqual(0, metro_boomin.lastPos)
+        self.assertEqual(1, metro_boomin.weeks)
+


### PR DESCRIPTION
As pointed out in #49 and #50, isNew is not listed correctly for #1 debuts, and we default to 0 weeks for new entries when really we should start counting at 1. 