### PR TITLE
Add the title attribute to ChartData

### DIFF
--- a/billboard.py
+++ b/billboard.py
@@ -21,7 +21,7 @@ HEADERS = {
 }
 
 # css selector constants
-_CHART_NAME_SELECTOR = 'h1.chart-detail-header__chart-name'
+_CHART_NAME_SELECTOR = 'meta[name="twitter:title"]'
 _DATE_ELEMENT_SELECTOR = 'button.chart-detail-header__date-selector-button'
 _PREVIOUS_DATE_SELECTOR = 'span.fa-chevron-left'
 _NEXT_DATE_SELECTOR = 'span.fa-chevron-right'
@@ -184,19 +184,6 @@ class ChartData:
         """
         return len(self.entries)
 
-    def _titleCase(self, title):
-        """Returns the given string in title case. This method improves
-        on the Python string.title() method by lowercasing some words."""
-        word_list = title.title().split()
-        if len(word_list) == 0:
-            return ''
-
-        exceptions = ['a', 'an', 'by', 'is', 'of', 'the']
-        final = [word_list[0]]
-        for word in word_list[1:]:
-            final.append(word.lower() if word.lower() in exceptions else word)
-        return " ".join(final)
-
     def json(self):
         """Returns the entry as a JSON string.
         This is useful for caching.
@@ -228,12 +215,9 @@ class ChartData:
             dateText = dateElement.text.strip()
             self.date = datetime.datetime.strptime(dateText, '%B %d, %Y').strftime('%Y-%m-%d')
 
-        chartTitleElement = soup.select_one(_CHART_NAME_SELECTOR);
+        chartTitleElement = soup.select_one(_CHART_NAME_SELECTOR)
         if chartTitleElement:
-            if chartTitleElement.img is not None:
-                self.title = chartTitleElement.img['alt'].strip()
-            else:
-                self.title = self._titleCase(chartTitleElement.text.strip())
+            self.title = chartTitleElement.get("content", "").split('|')[0].strip()
 
         prevWeek = soup.select_one(_PREVIOUS_DATE_SELECTOR)
         nextWeek = soup.select_one(_NEXT_DATE_SELECTOR)

--- a/tests/test_artist_100.py
+++ b/tests/test_artist_100.py
@@ -66,9 +66,6 @@ class TestHistoricalArtist100(TestCurrentArtist100):
         self.assertEqual(self.chart.previousDate, '2014-07-19')
         self.assertEqual(self.chart.nextDate, '2014-08-02')
 
-    def test_title(self):
-        self.assertEqual(self.chart.title, 'Artist 100')
-
     def test_entries_correctness(self):
         reference_path = os.path.join(get_test_dir(),
                                       '2014-07-26-artist-100.txt')

--- a/tests/test_artist_100.py
+++ b/tests/test_artist_100.py
@@ -19,6 +19,9 @@ class TestCurrentArtist100(unittest.TestCase):
     def test_date(self):
         self.assertIsNotNone(self.chart.date)
 
+    def test_title(self):
+        self.assertEqual(self.chart.title, 'Artist 100')
+
     def test_ranks(self):
         ranks = list(entry.rank for entry in self.chart)
         self.assertEqual(ranks, list(range(1, 101)))
@@ -62,6 +65,9 @@ class TestHistoricalArtist100(TestCurrentArtist100):
         self.assertEqual(self.chart.date, '2014-07-26')
         self.assertEqual(self.chart.previousDate, '2014-07-19')
         self.assertEqual(self.chart.nextDate, '2014-08-02')
+
+    def test_title(self):
+        self.assertEqual(self.chart.title, 'Artist 100')
 
     def test_entries_correctness(self):
         reference_path = os.path.join(get_test_dir(),

--- a/tests/test_digital_albums.py
+++ b/tests/test_digital_albums.py
@@ -59,9 +59,6 @@ class TestHistoricalDigitalAlbums(TestCurrentDigitalAlbums):
     def setUp(self):
         self.chart = billboard.ChartData('digital-albums', date='2017-03-04')
 
-    def test_title(self):
-        self.assertEqual(self.chart.title, 'Digital Albums')
-
     def test_date(self):
         self.assertEqual(self.chart.date, '2017-03-04')
         self.assertEqual(self.chart.previousDate, '2017-02-25')

--- a/tests/test_digital_albums.py
+++ b/tests/test_digital_albums.py
@@ -17,6 +17,9 @@ class TestCurrentDigitalAlbums(unittest.TestCase):
     def test_date(self):
         self.assertIsNotNone(self.chart.date)
 
+    def test_title(self):
+        self.assertEqual(self.chart.title, 'Digital Albums')
+
     def test_ranks(self):
         ranks = list(entry.rank for entry in self.chart)
         self.assertEqual(ranks, list(range(1, 26)))
@@ -55,6 +58,9 @@ class TestHistoricalDigitalAlbums(TestCurrentDigitalAlbums):
 
     def setUp(self):
         self.chart = billboard.ChartData('digital-albums', date='2017-03-04')
+
+    def test_title(self):
+        self.assertEqual(self.chart.title, 'Digital Albums')
 
     def test_date(self):
         self.assertEqual(self.chart.date, '2017-03-04')

--- a/tests/test_greatest_hot_100_singles.py
+++ b/tests/test_greatest_hot_100_singles.py
@@ -15,6 +15,10 @@ class TestCurrentGreatestHot100Singles(unittest.TestCase):
     def setUp(self):
         self.chart = billboard.ChartData('greatest-hot-100-singles')
 
+    def test_title(self):
+        self.assertEqual(self.chart.title,
+                         'Greatest of All Time Hot 100 Singles')
+
     def test_date(self):
         self.assertIsNone(self.chart.date)  # This chart has no dates
 

--- a/tests/test_hot_100.py
+++ b/tests/test_hot_100.py
@@ -18,7 +18,7 @@ class TestCurrentHot100(unittest.TestCase):
         self.assertIsNotNone(self.chart.date)
 
     def test_title(self):
-        self.assertEqual(self.chart.title, 'The Hot 100');
+        self.assertEqual(self.chart.title, 'The Hot 100')
 
     def test_ranks(self):
         ranks = list(entry.rank for entry in self.chart)
@@ -63,9 +63,6 @@ class TestHistoricalHot100(TestCurrentHot100):
         self.assertEqual(self.chart.date, '2015-11-28')
         self.assertEqual(self.chart.previousDate, '2015-11-21')
         self.assertEqual(self.chart.nextDate, '2015-12-05')
-
-    def test_title(self):
-        self.assertEqual(self.chart.title, 'The Hot 100');
 
     def test_entries_correctness(self):
         reference_path = os.path.join(get_test_dir(), '2015-11-28-hot-100.txt')

--- a/tests/test_hot_100.py
+++ b/tests/test_hot_100.py
@@ -17,6 +17,9 @@ class TestCurrentHot100(unittest.TestCase):
     def test_date(self):
         self.assertIsNotNone(self.chart.date)
 
+    def test_title(self):
+        self.assertEqual(self.chart.title, 'The Hot 100');
+
     def test_ranks(self):
         ranks = list(entry.rank for entry in self.chart)
         self.assertEqual(ranks, list(range(1, 101)))
@@ -60,6 +63,9 @@ class TestHistoricalHot100(TestCurrentHot100):
         self.assertEqual(self.chart.date, '2015-11-28')
         self.assertEqual(self.chart.previousDate, '2015-11-21')
         self.assertEqual(self.chart.nextDate, '2015-12-05')
+
+    def test_title(self):
+        self.assertEqual(self.chart.title, 'The Hot 100');
 
     def test_entries_correctness(self):
         reference_path = os.path.join(get_test_dir(), '2015-11-28-hot-100.txt')

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -23,3 +23,10 @@ class MiscTest(unittest.TestCase):
         chart = billboard.ChartData('hot-100', date='2018-01-27')
         self.assertEqual(chart[97].title, six.text_type(
             'El Bano'))  # With Unicode this should be "El Baño"
+    
+    def test_difficult_title_casing(self):
+        """Checks that a difficult chart title receives proper casing."""
+        chart = billboard.ChartData('greatest-r-b-hip-hop-songs')
+        self.assertEqual(chart.title,
+                         'Greatest of All Time Hot R&B/Hip-Hop Songs')
+


### PR DESCRIPTION
I would like to be able to get the human-readable name of a chart from ChartData objects. Right now I can only get the "name" attribute, which can't always be converted to the full name of the chart.

This PR adds a "title" attribute to instances of the ChartData class. This attribute contains the human-readable name of the chart, e.g. "The Hot 100" or "Digital Albums".

There is no one place in the chart pages where the chart name is consistently given across all charts, with proper casing. Therefore we look at both the alt text of the h1 image, if it exists, and otherwise
we take the all-caps text from the h1 element and do our own title casing on it.

The title casing logic does not handle all possible strings, but it works with nearly all known Billboard chart names. The only exceptions are the charts with "LyricFind" in the name, which will be rendered
"Lyricfind".