### PR TITLE
Ensure Session adheres to correct transport adapter

### DIFF
--- a/billboard.py
+++ b/billboard.py
@@ -354,9 +354,9 @@ class ChartData:
         """
         if not self.date:
             # Fetch latest chart
-            url = "http://www.billboard.com/charts/%s" % (self.name)
+            url = "https://www.billboard.com/charts/%s" % (self.name)
         else:
-            url = "http://www.billboard.com/charts/%s/%s" % (self.name, self.date)
+            url = "https://www.billboard.com/charts/%s/%s" % (self.name, self.date)
 
         session = _get_session_with_retries(max_retries=self._max_retries)
         req = session.get(url, timeout=self._timeout)
@@ -384,5 +384,8 @@ def charts():
 
 def _get_session_with_retries(max_retries):
     session = requests.Session()
-    session.mount("", requests.adapters.HTTPAdapter(max_retries=max_retries))
+    session.mount(
+        "https://www.billboard.com",
+        requests.adapters.HTTPAdapter(max_retries=max_retries),
+    )
     return session


### PR DESCRIPTION
Issue: #64 
Ensures program doesn't error out immediately in the case of a 429 response from billboard. 

**Edit:**
Prior to this PR, there was a bug within the `_get_session_with_retries` method. The `session.mount` statement did not specify a url prefix("" was just passed in) and because of this the Session object grabbed a default adapter with `max_retries` set to 0. This led to the Session returning a 429 instead of waiting and retrying.

Changes:
* ~~Add conditionals to fetchEntries to check for billboard response status code~~
* ~~Grabs `Retry-After` response header, pauses program for that amount of time~~
* Specify request url within `session.mount` statement
* Change billboard request urls to `https://`