### PR TITLE
Add support for year-end charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.1.3 &ndash; 2020-10-17
+### Added
+- Add test_year_end_charts.py
+
 ## 6.1.2 &ndash; 2020-09-15
 ### Fixed
 - Fix parsing of `artist` for entries that are missing artists (#71).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for year-end charts (#69, #33)
 - Add tests for year-end charts
 
-## 6.1.3 &ndash; 2020-10-17
-### Added
-- Add test_year_end_charts.py
-
 ## 6.1.2 &ndash; 2020-09-15
 ### Fixed
 - Fix parsing of `artist` for entries that are missing artists (#71).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.2.1 &ndash; 2020-10-25
+### Added
+- Add a warning for unsupported years.
+- Add a test for the unsupported year warning.
+
 ## 6.2.0 &ndash; 2020-10-18
 ### Added
-- Add support for year-end charts (#69, #33)
-- Add tests for year-end charts
+- Add support for year-end charts (#69, #33).
+- Add tests for year-end charts.
 
 ## 6.1.2 &ndash; 2020-09-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.2.0 &ndash; 2020-10-18
+### Added
+- Add support for year-end charts (#69, #33)
+- Add tests for year-end charts
+
 ## 6.1.3 &ndash; 2020-10-17
 ### Added
 - Add test_year_end_charts.py

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ hot-100 chart from 2018-04-28
 # ...
 ```
 
+We are also able to search for year-end charts:
+
+```python
+>>> chart = billboard.ChartData('alternative-songs', year=2006)
+>>> chart.title
+'Alternative Songs - Year-End'
+```
+
 Guide
 -----
 
@@ -69,6 +77,17 @@ Use the `charts` function to list all chart names:
 ```
 
 Alternatively, the bottom of [this page](https://www.billboard.com/charts) shows all charts grouped by category.
+
+The year-end charts can be listed by setting `year_end` to `True`:
+
+```python
+>>> billboard.charts(year_end=True)
+['top-artists', 'top-artists-duo-group', 'top-artists-female', ...
+```
+
+The year-end chart list is also [available online](https://www.billboard.com/charts/year-end).
+
+
 
 ### Downloading a chart
 
@@ -95,7 +114,7 @@ chart = billboard.ChartData('hot-100')
 while chart.previousDate:
     doSomething(chart)
     chart = billboard.ChartData('hot-100', chart.previousDate)
-``` 
+```
 
 ### Accessing chart entries
 
@@ -167,7 +186,7 @@ Have an addition? Make a pull request!
 Dependencies
 ------------
 * [Beautiful Soup 4](http://www.crummy.com/software/BeautifulSoup/)
-* [Requests](http://requests.readthedocs.org/en/latest/) 
+* [Requests](http://requests.readthedocs.org/en/latest/)
 
 License
 -------

--- a/billboard.py
+++ b/billboard.py
@@ -113,12 +113,11 @@ class YearEndChartEntry(ChartEntry):
         year: The chart's year, as an int.
     """
 
-    def __init__(self, title, artist, image, rank, year):
+    def __init__(self, title, artist, image, rank):
         self.title = title
         self.artist = artist
         self.image = image
         self.rank = rank
-        self.year = year
 
 
 class ChartData:
@@ -442,7 +441,7 @@ class ChartData:
             image = getEntryAttr("div.ye-chart-item__image", image=True)
             rank = int(getEntryAttr("div.ye-chart-item__rank"))
 
-            entry = YearEndChartEntry(title, artist, image, rank, self.year)
+            entry = YearEndChartEntry(title, artist, image, rank)
             self.entries.append(entry)
 
     def _parsePage(self, soup):

--- a/billboard.py
+++ b/billboard.py
@@ -77,8 +77,7 @@ class ChartEntry:
         )
 
     def __str__(self):
-        """Returns a string of the form 'TITLE by ARTIST'.
-        """
+        """Returns a string of the form 'TITLE by ARTIST'."""
         if self.title:
             s = u"'%s' by %s" % (self.title, self.artist)
         else:
@@ -107,6 +106,7 @@ class YearEndChartEntry(ChartEntry):
         image: The URL of the image for the track.
         rank: The track's position on the chart, as an int.
     """
+
     def __init__(self, title, artist, image, rank):
         self.title = title
         self.artist = artist
@@ -127,7 +127,9 @@ class ChartData:
             (highest first).
     """
 
-    def __init__(self, name, date=None, year=None, fetch=True, max_retries=5, timeout=25):
+    def __init__(
+        self, name, date=None, year=None, fetch=True, max_retries=5, timeout=25
+    ):
         """Constructs a new ChartData instance.
 
         Args:
@@ -191,8 +193,7 @@ class ChartData:
         )
 
     def __str__(self):
-        """Returns the chart as a human-readable string (typically multi-line).
-        """
+        """Returns the chart as a human-readable string (typically multi-line)."""
         if not self.date:
             s = "%s chart (current)" % self.name
         else:
@@ -415,9 +416,7 @@ class ChartData:
             image = getEntryAttr("div.ye-chart-item__image", image=True)
             rank = int(getEntryAttr("div.ye-chart-item__rank"))
 
-            entry = YearEndChartEntry(
-                title, artist, image, rank
-            )
+            entry = YearEndChartEntry(title, artist, image, rank)
             self.entries.append(entry)
 
     def _parsePage(self, soup):
@@ -445,7 +444,10 @@ class ChartData:
                 # Fetch latest chart
                 url = "https://www.billboard.com/charts/%s" % (self.name)
             else:
-                url = "https://www.billboard.com/charts/year-end/%s/%s" % (self.year, self.name)
+                url = "https://www.billboard.com/charts/year-end/%s/%s" % (
+                    self.year,
+                    self.name,
+                )
         else:
             url = "https://www.billboard.com/charts/%s/%s" % (self.name, self.date)
 

--- a/billboard.py
+++ b/billboard.py
@@ -456,11 +456,17 @@ class ChartData:
         self._parsePage(soup)
 
 
-def charts():
+def charts(year_end=False):
     """Gets a list of all Billboard charts from Billboard.com.
+
+    Args:
+        year_end: If True, will list Billboard's year-end charts.
     """
     session = _get_session_with_retries(max_retries=5)
-    req = session.get("https://www.billboard.com/charts", timeout=25)
+    url = "https://www.billboard.com/charts"
+    if year_end:
+        url += "/year-end"
+    req = session.get(url, timeout=25)
     req.raise_for_status()
     soup = BeautifulSoup(req.text, "html.parser")
     return [

--- a/billboard.py
+++ b/billboard.py
@@ -373,7 +373,7 @@ class ChartData:
         # Parse the chart's year from its URL
         try:
             href = soup.select_one("link").get("href")
-            self.year = str(re.search(r"/(1|2\d{3})/", href).group(1))
+            self.year = str(re.search(r"/((1|2)\d{3})/", href).group(1))
         except AttributeError:
             message = "Could not find a year in the URL."
             raise BillboardNotFoundException(message)
@@ -382,12 +382,12 @@ class ChartData:
         years = soup.select_one("ul.dropdown__year-select-options")
         year_links = [li.get("href") for li in years.find_all("a")]
         idx = [i for i, yl in enumerate(year_links) if self.year in yl]
-        if not idx:
-            message = f"'{self.year}' was not found in the page's year list."
-            raise BillboardNotFoundException(message)
-        idx = idx[0]
-        self.previousYear = year_links[min(idx + 1, len(year_links) - 1)]
-        self.nextYear = year_links[max(idx - 1, 0)]
+        if idx:
+            idx = idx[0]
+            self.previousYear = year_links[min(idx + 1, len(year_links) - 1)]
+            self.nextYear = year_links[max(idx - 1, 0)]
+        else:
+            self.previousYear = self.nextYear = None
 
         # Access each element from the chart
         def getEntryAttr(selector, image=False):

--- a/billboard.py
+++ b/billboard.py
@@ -182,6 +182,10 @@ class ChartData:
             self.fetchEntries()
 
     def __repr__(self):
+        if self.year:
+            return "{}.{}({!r}, year={!r})".format(
+                self.__class__.__module__, self.__class__.__name__, self.name, self.year
+            )
         return "{}.{}({!r}, date={!r})".format(
             self.__class__.__module__, self.__class__.__name__, self.name, self.date
         )

--- a/billboard.py
+++ b/billboard.py
@@ -113,7 +113,7 @@ class YearEndChartEntry(ChartEntry):
         self.artist = artist
         self.image = image
         self.rank = rank
-        self.year = int(year)
+        self.year = year
 
 
 class ChartData:
@@ -175,7 +175,7 @@ class ChartData:
                 raise ValueError("Year argument is not in YYYY format")
 
         self.date = date
-        self.year = int(year)
+        self.year = year
         self.title = ""
 
         self._max_retries = max_retries
@@ -382,7 +382,7 @@ class ChartData:
         # Parse the chart's year from its URL
         def get_year_from_url(url):
             pattern = re.compile(r"/((1|2)\d{3})/")
-            return int(re.search(pattern, url).group(1))
+            return str(re.search(pattern, url).group(1))
 
         try:
             href = soup.select_one("link").get("href")
@@ -394,11 +394,11 @@ class ChartData:
         # Determine the next and previous year-end chart
         year_links = soup.select_one("ul.dropdown__year-select-options")
         year_links = [li.get("href") for li in year_links.find_all("a")]
-        years = list(map(get_year_from_url, year_links))
-        max_year = max(years)
+        max_year = int(max(map(get_year_from_url, year_links)))
         min_year = 1940
-        self.previousYear = self.year - 1 if self.year > min_year else None
-        self.nextYear = self.year + 1 if self.year < max_year else None
+        current_year = int(self.year)
+        self.previousYear = str(current_year - 1) if current_year > min_year else None
+        self.nextYear = str(current_year + 1) if current_year < max_year else None
 
         # Access each element from the chart
         def getEntryAttr(selector, image=False):

--- a/billboard.py
+++ b/billboard.py
@@ -142,7 +142,8 @@ class ChartData:
                 Billboard automatically rounds dates up to the nearest date on
                 which a chart was published.
                 If this argument is invalid, no exception will be raised;
-                instead, the chart will contain no entries.
+                instead, the chart will contain no entries. Cannot supply
+                both `date` and `year`.
             year: The chart year, if requesting a year-end chart. Must
                 be a string in YYYY format. Cannot supply both `date`
                 and `year`.
@@ -195,7 +196,9 @@ class ChartData:
 
     def __str__(self):
         """Returns the chart as a human-readable string (typically multi-line)."""
-        if not self.date:
+        if self.year:
+            s = "%s chart (%s)" % (self.name, self.year)
+        elif not self.date:
             s = "%s chart (current)" % self.name
         else:
             s = "%s chart from %s" % (self.name, self.date)
@@ -429,10 +432,10 @@ class ChartData:
                 chartTitleElement.get("content", "").split("|")[0].strip(),
             )
 
-        if soup.select("table"):
-            self._parseOldStylePage(soup)
-        elif self.year:
+        if self.year:
             self._parseYearEndPage(soup)
+        elif soup.select("table"):
+            self._parseOldStylePage(soup)
         else:
             self._parseNewStylePage(soup)
 

--- a/billboard.py
+++ b/billboard.py
@@ -105,13 +105,15 @@ class YearEndChartEntry(ChartEntry):
             be included in this string.
         image: The URL of the image for the track.
         rank: The track's position on the chart, as an int.
+        year: The chart's year, as a str.
     """
 
-    def __init__(self, title, artist, image, rank):
+    def __init__(self, title, artist, image, rank, year):
         self.title = title
         self.artist = artist
         self.image = image
         self.rank = rank
+        self.year = year
 
 
 class ChartData:
@@ -174,7 +176,6 @@ class ChartData:
         self.date = date
         self.year = year
         self.title = ""
-        self.previousDate = None
 
         self._max_retries = max_retries
         self._timeout = timeout
@@ -416,7 +417,7 @@ class ChartData:
             image = getEntryAttr("div.ye-chart-item__image", image=True)
             rank = int(getEntryAttr("div.ye-chart-item__rank"))
 
-            entry = YearEndChartEntry(title, artist, image, rank)
+            entry = YearEndChartEntry(title, artist, image, rank, self.year)
             self.entries.append(entry)
 
     def _parsePage(self, soup):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="billboard.py",
-    version="6.1.3",  # Don't forget to update CHANGELOG.md!
+    version="6.2.0",  # Don't forget to update CHANGELOG.md!
     description="Python API for downloading Billboard charts",
     author="Allen Guo",
     author_email="guoguo12@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="billboard.py",
-    version="6.1.2",  # Don't forget to update CHANGELOG.md!
+    version="6.1.3",  # Don't forget to update CHANGELOG.md!
     description="Python API for downloading Billboard charts",
     author="Allen Guo",
     author_email="guoguo12@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="billboard.py",
-    version="6.2.0",  # Don't forget to update CHANGELOG.md!
+    version="6.2.1",  # Don't forget to update CHANGELOG.md!
     description="Python API for downloading Billboard charts",
     author="Allen Guo",
     author_email="guoguo12@gmail.com",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -36,3 +36,12 @@ class MiscTest(unittest.TestCase):
         charts = billboard.charts()
         self.assertTrue("hot-100" in charts)
         self.assertTrue(100 <= len(charts) <= 400)
+
+    def testChartsYearEnd(self):
+        """Checks that the function for listing all year-end charts
+        returns reasonable results."""
+        charts = billboard.charts(year_end=True)
+        chart_names = ["top-artists", "radio-songs", "top-country-albums"]
+        for name in chart_names:
+            self.assertTrue(name in charts)
+        self.assertTrue(300 <= len(charts) <= 500)

--- a/tests/test_year_end_charts.py
+++ b/tests/test_year_end_charts.py
@@ -18,6 +18,10 @@ class Base:
     def testTitle(self):
         self.assertEqual(self.chart.title, self.expectedTitle)
 
+    def testRanks(self):
+        ranks = list(entry.rank for entry in self.chart)
+        self.assertEqual(ranks, sorted(ranks))
+
     def testEntriesValidity(self, skipTitleCheck=False):
         self.assertEqual(len(self.chart), self.expectedNumEntries)
         for entry in self.chart:
@@ -53,3 +57,24 @@ class TestHotCountrySongs2010(Base, unittest.TestCase):
         cls.chart = billboard.ChartData("hot-country-songs", year="2010")
         cls.expectedTitle = "Hot Country Songs - Year-End"
         cls.expectedNumEntries = 60
+
+
+class TestHotCountrySongs1970(Base, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.chart = billboard.ChartData("hot-country-songs", year="1970")
+        cls.expectedTitle = "Hot Country Songs - Year-End"
+        cls.expectedNumEntries = 34
+
+
+class TestJazzAlbumsImprints2006(Base, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.chart = billboard.ChartData("jazz-imprints", year="2006")
+        cls.expectedTitle = "Jazz Albums Imprints - Year-End"
+        cls.expectedNumEntries = 9
+
+    def testEntriesValidity(self):
+        super(TestJazzAlbumsImprints2006, self).testEntriesValidity(skipTitleCheck=True)
+        for entry in self.chart:
+            self.assertEqual(entry.title, "")  # This chart has no titles

--- a/tests/test_year_end_charts.py
+++ b/tests/test_year_end_charts.py
@@ -43,22 +43,6 @@ class TestHot100Songs(Base, unittest.TestCase):
         cls.expectedNumEntries = 100
 
 
-class TestHotCountrySongs2019(Base, unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.chart = billboard.ChartData("hot-country-songs", year="2019")
-        cls.expectedTitle = "Hot Country Songs - Year-End"
-        cls.expectedNumEntries = 100
-
-
-class TestHotCountrySongs2010(Base, unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.chart = billboard.ChartData("hot-country-songs", year="2010")
-        cls.expectedTitle = "Hot Country Songs - Year-End"
-        cls.expectedNumEntries = 60
-
-
 class TestHotCountrySongs1970(Base, unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_year_end_charts.py
+++ b/tests/test_year_end_charts.py
@@ -15,6 +15,12 @@ class Base:
     def testYear(self):
         self.assertIsNotNone(self.chart.year)
 
+    def testNextYear(self):
+        self.assertEqual(self.chart.nextYear, self.chart.year + 1)
+
+    def testPreviousYear(self):
+        self.assertEqual(self.chart.previousYear, self.chart.year - 1)
+
     def testTitle(self):
         self.assertEqual(self.chart.title, self.expectedTitle)
 
@@ -35,12 +41,15 @@ class Base:
             self.assertTrue(json.loads(entry.json()))
 
 
-class TestHot100Songs(Base, unittest.TestCase):
+class TestHot100Songs2019(Base, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.chart = billboard.ChartData("hot-100-songs", year="2019")
         cls.expectedTitle = "Hot 100 Songs - Year-End"
         cls.expectedNumEntries = 100
+
+    def testNextYear(self):
+        self.assertEqual(self.chart.nextYear, None)
 
 
 class TestHotCountrySongs1970(Base, unittest.TestCase):

--- a/tests/test_year_end_charts.py
+++ b/tests/test_year_end_charts.py
@@ -1,6 +1,5 @@
 import abc
 import json
-import os
 import six
 import unittest
 import billboard
@@ -30,3 +29,27 @@ class Base:
         self.assertTrue(json.loads(self.chart.json()))
         for entry in self.chart:
             self.assertTrue(json.loads(entry.json()))
+
+
+class TestHot100Songs(Base, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.chart = billboard.ChartData("hot-100-songs", year="2019")
+        cls.expectedTitle = "Hot 100 Songs - Year-End"
+        cls.expectedNumEntries = 100
+
+
+class TestHotCountrySongs2019(Base, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.chart = billboard.ChartData("hot-country-songs", year="2019")
+        cls.expectedTitle = "Hot Country Songs - Year-End"
+        cls.expectedNumEntries = 100
+
+
+class TestHotCountrySongs2010(Base, unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.chart = billboard.ChartData("hot-country-songs", year="2010")
+        cls.expectedTitle = "Hot Country Songs - Year-End"
+        cls.expectedNumEntries = 60

--- a/tests/test_year_end_charts.py
+++ b/tests/test_year_end_charts.py
@@ -1,0 +1,32 @@
+import abc
+import json
+import os
+import six
+import unittest
+import billboard
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Base:
+    @classmethod
+    @abc.abstractmethod
+    def setUpClass(cls):
+        pass
+
+    def testYear(self):
+        self.assertIsNotNone(self.chart.year)
+
+    def testTitle(self):
+        self.assertEqual(self.chart.title, self.expectedTitle)
+
+    def testEntriesValidity(self, skipTitleCheck=False):
+        self.assertEqual(len(self.chart), self.expectedNumEntries)
+        for entry in self.chart:
+            if not skipTitleCheck:
+                self.assertGreater(len(entry.title), 0)
+            self.assertGreater(len(entry.artist), 0)
+
+    def testJson(self):
+        self.assertTrue(json.loads(self.chart.json()))
+        for entry in self.chart:
+            self.assertTrue(json.loads(entry.json()))

--- a/tests/test_year_end_charts.py
+++ b/tests/test_year_end_charts.py
@@ -16,10 +16,12 @@ class Base:
         self.assertIsNotNone(self.chart.year)
 
     def testNextYear(self):
-        self.assertEqual(self.chart.nextYear, self.chart.year + 1)
+        next_year = str(int(self.chart.year) + 1)
+        self.assertEqual(self.chart.nextYear, next_year)
 
     def testPreviousYear(self):
-        self.assertEqual(self.chart.previousYear, self.chart.year - 1)
+        previous_year = str(int(self.chart.year) - 1)
+        self.assertEqual(self.chart.previousYear, previous_year)
 
     def testTitle(self):
         self.assertEqual(self.chart.title, self.expectedTitle)


### PR DESCRIPTION
Hi Allen,

Thanks for the excellent library! I've found `billboard.py` easy to use and have been impressed with the quality of its results and the organization of your code.

The project I'm working on requires data from year-end charts, so I thought I'd add support for those to your package. I see this functionality has been attempted before in other PRs (#34, #47), but I believe my approach is most consistent with the style you've already developed, and it introduces very little additional complexity for the user. This PR resolves #33 and resolves #69.

The user can access year-end charts by specifying the chart name and year in the `ChartData` class:

```python
>>> chart = billboard.ChartData("hot-100-songs", year="2019")
>>> chart.title
'Hot 100 Songs - Year-End'
```

I also modified the `charts` function to accept a `year_end` option:
```python
>>> billboard.charts(year_end=True)
['top-artists', 'top-artists-duo-group', 'top-artists-female', ...
```

Following [your advice](https://github.com/guoguo12/billboard-charts/pull/34#issuecomment-404707863) in #34, I also wrote a `YearEndChartEntry` subclass of `ChartEntry`.

The five tests I wrote for year-end charts are all passing on my local machine. For completeness, there could still be historical tests added using your JSON format in `test_historical_charts.py`.