### PR TITLE
Fix date edge cases

### DIFF
--- a/billboard.py
+++ b/billboard.py
@@ -240,8 +240,12 @@ class ChartData:
         nextWeek = soup.select_one(_NEXT_DATE_SELECTOR)
         if prevWeek and prevWeek.parent.get("href"):
             self.previousDate = prevWeek.parent.get("href").split("/")[-1]
+        else:
+            self.previousDate = ""
         if nextWeek and nextWeek.parent.get("href"):
             self.nextDate = nextWeek.parent.get("href").split("/")[-1]
+        else:
+            self.nextDate = ""
 
         for entrySoup in soup.select(_ENTRY_LIST_SELECTOR):
             try:

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -23,11 +23,23 @@ class DateTest(unittest.TestCase):
         """
         chart = billboard.ChartData("hot-100", date="1962-01-06")
         self.assertEqual(chart.date, "1962-01-06")
+        self.assertEqual(chart.nextDate, "1962-01-13")
         self.assertEqual(chart.previousDate, "1961-12-25")
 
         chart = billboard.ChartData("hot-100", date="1961-12-25")
         self.assertEqual(chart.date, "1961-12-25")
         self.assertEqual(chart.nextDate, "1962-01-06")
+        self.assertEqual(chart.previousDate, "1961-12-18")
+
+        chart = billboard.ChartData("country-songs", date="1958-10-20")
+        self.assertEqual(chart.date, "1958-10-20")
+        self.assertEqual(chart.nextDate, "1958-10-27")
+        self.assertEqual(chart.previousDate, "")
+
+        chart = billboard.ChartData("country-streaming-songs", date="2020-10-31")
+        self.assertEqual(chart.date, "2020-10-31")
+        self.assertEqual(chart.nextDate, "")
+        self.assertEqual(chart.previousDate, "2020-10-24")
 
     def testDatetimeDate(self):
         """Checks that ChartData correctly handles datetime objects as the


### PR DESCRIPTION
This PR resolves #78 by setting `previousDate` and `nextDate` to `""` when old-style charts hit either the lower or upper range of dates available from Billboard.

I also added two additional tests to the `test_dates.py` file to make sure the old-style charts are being tested. Feel free to remove or modify them, @guoguo12, if you'd prefer to not add to the total test count.