### PR TITLE
Non-Permanent fix for tiktok charts

### DIFF
--- a/billboard.py
+++ b/billboard.py
@@ -377,7 +377,7 @@ class ChartData:
                         return int(value)
                 except:
                     message = "Failed to parse metadata value: %s" % attribute
-                    raise BillboardParseException(message)
+                    # raise BillboardParseException(message)
 
             if self.date:
                 peakPos = getMeta("peak", 4)


### PR DESCRIPTION
This fix will only comment the line of code that raises an exception from not being able to parse the week. This fix is not permanent and does not make any sense for long term but will allow users to use the tik tok chart. If I had more time I would provide a better fix