### PR TITLE
handle non-intable strings better

### DIFF
--- a/billboard.py
+++ b/billboard.py
@@ -320,7 +320,8 @@ class ChartData:
     def _pageHasAwardColumn(self, soup):
         cols = soup.select(_CHART_HEADER_CELLS)
         for span in cols:
-            if "award" in span.string.lower():
+            text = getattr(span, "string", None) or (span.get_text() if span else "")
+            if text and "award" in text.lower():
                 return True
         return False
 
@@ -374,17 +375,25 @@ class ChartData:
 
             def getMeta(attribute, which_li, ifNoValue=None):
                 try:
-                    selected = entrySoup.select_one("ul").select("li")[which_li]
-
+                    ulist = entrySoup.select_one("ul")
+                    if not ulist:
+                        return ifNoValue
+                    lis = ulist.select("li")
+                    if which_li >= len(lis):
+                        return ifNoValue
+                    selected = lis[which_li]
                     if not selected:
                         return ifNoValue
 
-                    value = selected.text.strip()
+                    value = selected.get_text(" ", strip=True)
+                    # Spacer <li> may be empty; never call int("").
+                    if not value or value == "-":
+                        return ifNoValue
                     try:
                         return int(value)
                     except ValueError:
                         return ifNoValue
-                except:
+                except Exception:
                     message = "Failed to parse metadata value: %s" % attribute
                     raise BillboardParseException(message)
 

--- a/billboard.py
+++ b/billboard.py
@@ -294,10 +294,10 @@ class ChartData:
                             headingText = heading.string.strip().lower()
                             if headingText == fieldName:
                                 value = ministat.text.split(u"\xa0")[0].strip()
-                                if value is None or value == "-":
-                                    return ifNoValue
-                                else:
+                                try:
                                     return int(value)
+                                except ValueError:
+                                    return ifNoValue
                         return ifNoValue
                     except Exception as e:
                         print(e)
@@ -380,10 +380,10 @@ class ChartData:
                         return ifNoValue
 
                     value = selected.text.strip()
-                    if value == "-":
-                        return ifNoValue
-                    else:
+                    try:
                         return int(value)
+                    except ValueError:
+                        return ifNoValue
                 except:
                     message = "Failed to parse metadata value: %s" % attribute
                     raise BillboardParseException(message)


### PR DESCRIPTION
Getting errors today of the shape
```
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.8/site-packages/billboard.py", line 374, in getMeta
    return int(value)
ValueError: invalid literal for int() with base 10: ''

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  ...
  File "/home/user/.local/lib/python3.8/site-packages/billboard.py", line 190, in __init__
    self.fetchEntries()
  File "/home/user/.local/lib/python3.8/site-packages/billboard.py", line 489, in fetchEntries
    self._parsePage(soup)
  File "/home/user/.local/lib/python3.8/site-packages/billboard.py", line 463, in _parsePage
    self._parseNewStylePage(soup)
  File "/home/user/.local/lib/python3.8/site-packages/billboard.py", line 382, in _parseNewStylePage
    weeks = getMeta("week", 5, ifNoValue=1)
  File "/home/user/.local/lib/python3.8/site-packages/billboard.py", line 377, in getMeta
    raise BillboardParseException(message)
billboard.BillboardParseException: Failed to parse metadata value: week
```

Seems like the fix in this PR is the easiest, just return our `ifNotValue` for anything that isn't intable.